### PR TITLE
Add Asus AS239 to tested list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Download the latest app binary zip file from [here](https://github.com/czarny/Br
 * DELL U2717D
 * LG IPS235
 * IIYAMA PL2779Q
+* ASUS AS239


### PR DESCRIPTION
I have confirmed that this is able to control my AS239 displays over both a direct HDMI cable and an mDP-HDMI adapter 👍 