### PR TITLE
Correct 'dispaly' typos to 'display'

### DIFF
--- a/Brisync/DisplayManager.m
+++ b/Brisync/DisplayManager.m
@@ -43,7 +43,7 @@ NSString *DisplayGetDescription(CGDirectDisplayID display, UInt8 type) {
 - (instancetype)init {
     self = [super init];
     if(self) {
-        NSMutableArray *external_dispalys = [NSMutableArray new];
+        NSMutableArray *external_displays = [NSMutableArray new];
 
         // Get displays
         CGDirectDisplayID displays[kMaxDisplays];
@@ -58,11 +58,11 @@ NSString *DisplayGetDescription(CGDirectDisplayID display, UInt8 type) {
                 self->_builtinDisplay = display;
             }
             else {
-                [external_dispalys addObject:@(display)];
+                [external_displays addObject:@(display)];
             }
         }
 
-        self->_externalDisplays = [external_dispalys copy];
+        self->_externalDisplays = [external_displays copy];
     }
     return self;
 }

--- a/Brisync/MainController.m
+++ b/Brisync/MainController.m
@@ -100,7 +100,7 @@
     for(NSNumber *display_id in self->_displayManager.externalDisplays) {
         CGDirectDisplayID display = [display_id intValue];
 
-        DisplayUnitView *unit = [self createDispalyUnitView];
+        DisplayUnitView *unit = [self createDisplayUnitView];
         unit.name.stringValue = [self->_displayManager getDisplayName:display];
         unit.slider.tag = display;
 
@@ -127,7 +127,7 @@
 
 #pragma mark Private
 
-- (DisplayUnitView *)createDispalyUnitView {
+- (DisplayUnitView *)createDisplayUnitView {
     NSArray *o;
     [[NSBundle mainBundle] loadNibNamed:@"DisplayUnit" owner:nil topLevelObjects:&o];
     DisplayUnitView *result = [o.firstObject isKindOfClass:[DisplayUnitView class]]? o.firstObject : o.lastObject;


### PR DESCRIPTION
Noticed this minor typo repeated a few times while debugging something else, figured I'd send a minor patch :)

I checked with "Find in Project" to make sure I replaced all of them